### PR TITLE
Add API base URL config

### DIFF
--- a/mobileApp/src/config.js
+++ b/mobileApp/src/config.js
@@ -1,0 +1,1 @@
+export const API_BASE_URL = process.env.API_BASE_URL || 'http://172.20.10.2:8000';

--- a/mobileApp/src/screens/DocumentScreen.js
+++ b/mobileApp/src/screens/DocumentScreen.js
@@ -5,6 +5,7 @@ import { FetchDocuments } from '../utils/FetchDocuments';
 import AddNewDoc from '../components/AddNewDoc';
 import SearchBar from '../components/SearchBar';
 import axios from 'axios';
+import { API_BASE_URL } from '../config';
 import AsyncStorage from  '@react-native-async-storage/async-storage';
 
 const DocumentScreen = ({ navigation }) => {
@@ -21,7 +22,7 @@ const DocumentScreen = ({ navigation }) => {
         try {
             token = await AsyncStorage.getItem("access_token");
             console.log(token)
-            const response = await axios.get(`http://172.20.10.2:8000/user/search?query=${encodeURIComponent(query)}&top_k=2`,{
+            const response = await axios.get(`${API_BASE_URL}/user/search?query=${encodeURIComponent(query)}&top_k=2`,{
                 headers: {
                     'Authorization': `Bearer ${token}`
                 }

--- a/mobileApp/src/screens/LoginScreen.js
+++ b/mobileApp/src/screens/LoginScreen.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { View, TextInput, Text, ActivityIndicator } from 'react-native';
 import axios from 'axios';
+import { API_BASE_URL } from '../config';
 import { styles } from '../styles'; 
 import { TouchableOpacity } from 'react-native-gesture-handler';
 import { useUser } from "../contexts/UserContext"; 
@@ -21,7 +22,7 @@ const LoginScreen = ({ navigation }) => {
     try {
       const formData = `username=${userName}&password=${password}`;
       // http://192.168.1.16:8000/ or http://10.0.2.2:8000/ http://172.20.10.2:8000
-      const response = await axios.post('http://172.20.10.2:8000/login', formData, {
+      const response = await axios.post(`${API_BASE_URL}/login`, formData, {
         headers: {
           'Content-Type': 'application/x-www-form-urlencoded',
         },

--- a/mobileApp/src/screens/RegisterScreen.js
+++ b/mobileApp/src/screens/RegisterScreen.js
@@ -3,6 +3,7 @@ import { View, TextInput, Button, Text, ActivityIndicator } from 'react-native';
 import { styles } from '../styles'; 
 import { TouchableOpacity } from 'react-native-gesture-handler';
 import axios from 'axios';
+import { API_BASE_URL } from '../config';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { fetchUserInfo } from '../utils/FetchUserInfo';
 import { useUser } from '../contexts/UserContext';
@@ -29,7 +30,7 @@ const RegisterScreen = ({ navigation }) => {
     try {
       const formData = `username=${username}&email=${email}&password=${password}`;
 
-      const response = await axios.post('http://172.20.10.2:8000/register', formData, {
+      const response = await axios.post(`${API_BASE_URL}/register`, formData, {
         headers: {
           'Content-Type': 'application/x-www-form-urlencoded',
         },

--- a/mobileApp/src/utils/FetchDocuments.js
+++ b/mobileApp/src/utils/FetchDocuments.js
@@ -1,10 +1,11 @@
 import axios from 'axios';
 import AsyncStorage from '@react-native-async-storage/async-storage'
+import { API_BASE_URL } from '../config';
 
 export const FetchDocuments = async ({ path } = { path: null }) => {
     try {
         const token = await AsyncStorage.getItem("access_token");
-        const endpoint = "http://172.20.10.2:8000/user/documents";
+        const endpoint = `${API_BASE_URL}/user/documents`;
         const url = path ? `${endpoint}?path=${encodeURIComponent(path.join('/'))}` : endpoint;
         const response = await axios.get(url, {
             headers: {

--- a/mobileApp/src/utils/FetchUserInfo.js
+++ b/mobileApp/src/utils/FetchUserInfo.js
@@ -1,11 +1,12 @@
 import axios from 'axios';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useUser } from '../contexts/UserContext';
+import { API_BASE_URL } from '../config';
 
 export const fetchUserInfo = async (setUser, navigation) => {
     try {
         const token = await AsyncStorage.getItem("access_token");
-        const response = await axios.get("http://172.20.10.2:8000/users/me", {
+        const response = await axios.get(`${API_BASE_URL}/users/me`, {
             headers: {
                 Authorization: `Bearer ${token}`,
             },


### PR DESCRIPTION
## Summary
- add src/config.js exporting `API_BASE_URL`
- use API_BASE_URL in screens and utils for axios requests

## Testing
- `pytest -q` *(fails: command not found)*